### PR TITLE
Updated: Replaced php files short tag with standard php open tag to support extension use on servers which do not support short tags by default php.ini configuration

### DIFF
--- a/datatypes/ezbotrvideo/ezbotrvideo.php
+++ b/datatypes/ezbotrvideo/ezbotrvideo.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 class eZBotrVideo
 {

--- a/datatypes/ezvimeovideo/ezvimeovideo.php
+++ b/datatypes/ezvimeovideo/ezvimeovideo.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 class eZVimeoVideo
 {

--- a/modules/botr_video_dt/create_url.php
+++ b/modules/botr_video_dt/create_url.php
@@ -1,4 +1,5 @@
-<?
+<?php
+
 eZDebug::writeDebug('test');
 $ini = new eZINI('botr.ini');
 $Key = $ini->variable('BOTRSettings', 'Key');

--- a/modules/botr_video_dt/post_url.php
+++ b/modules/botr_video_dt/post_url.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 $vars = (count($_POST)) ? $_POST : $_GET;
 


### PR DESCRIPTION
Hello,

We recently were required to use this extension while working on a customer project and ran into problems which initially prevent us from using this solution.

We specifically ran into problems getting the datatype classes to be loaded using the ezpublish 4 / 5 autoload system because the PHP files did not contain the standard '<?php' starting tags at the top of the PHP class files ... also our server was naturally configured to not support short tags by default (since short tags usage in modern PHP is strongly frowned upon).

This PR solves this problem for all users and introduces zero problems for any existing users. This PR introduces zero problems for any existing users because the use of '<?php' starting tags is supported by default and has been for almost forever.

While fixing this problem and building this PR we also replaced the usage of short tags within all other PHP files provided by this extension.

Please merge our PR so that in the future all users (including us) can use this extension without making unnecessary php.ini short tag configuration changes.

Thank you for your consideration and continued support!

Cheers,
Brookins Consulting